### PR TITLE
Include MU-SESSION-ID header in sparql requests

### DIFF
--- a/repository.lisp
+++ b/repository.lisp
@@ -8,8 +8,25 @@
       (progn (format t "~&running on localhost~%")
          "http://localhost:8890")))
 
+(defclass mu-semtech-repository (cl-fuseki::virtuoso-repository)
+  ()
+  (:documentation "repository for mu-semtech Virtuoso endpoints."))
+
+(defun mu-semtech-headers ()
+  (list (cons :MU-SESSION-ID (webserver:header-in* :MU-SESSION-ID))))
+
+(defmethod fuseki::query-raw ((repos mu-semtech-repository) (query string)
+			      &rest options &key &allow-other-keys)
+  (fuseki::flush-updates repos)
+  (let ((full-query (apply #'fuseki::query-update-prefixes query options)))
+    (fuseki::maybe-log-query full-query)
+    (fuseki::send-request (fuseki::query-endpoint repos)
+                  :accept (fuseki::get-data-type-binding :json)
+                  :parameters `(("query" . ,full-query))
+		  :additional-headers (mu-semtech-headers))))
+
 (defparameter *repository*
-  (make-instance 'fuseki::virtuoso-repository :name "main repository"
+  (make-instance 'mu-semtech-repository :name "main repository"
                  :server (make-instance 'fuseki::virtuoso-server
                                         :base-url (server-location))))
 


### PR DESCRIPTION
Extends cl-fuseki::virtuoso-repository class and fuseki::query-raw
method to allow received headers to be passed on.